### PR TITLE
Fix className overwriting theme

### DIFF
--- a/src/toast.js
+++ b/src/toast.js
@@ -76,7 +76,7 @@ const show = function (message, options) {
 
     // Add Theme class to the class name list
     if(options.theme) {
-        className = (options.className) ? options.className : '' + " " + options.theme.trim();
+        className = ( (options.className) ? options.className : '' ) + " " + options.theme.trim();
         className = (className) ? className.trim() : className;
     }
 


### PR DESCRIPTION
Passing a className causes no theme to be applied.

Run in console to reproduce

```javascript
var options = {className:'class'}
options.theme = options.theme || "primary";
var reproduce = (options.className) ? options.className : '' + " " + options.theme.trim();
var fixed = ( (options.className) ? options.className : '' )+ " " + options.theme.trim();
console.log("reproduce: " + reproduce);
console.log("fixed: " + fixed);
```