### PR TITLE
New option closeOnSwipe: enable/disable the swipe to close behavior.

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,7 @@ Icon|String, Object|null|Material icon name as string.  [explained here](#icons)
 type|String|'default'| Type of the Toast  **['success', 'info', 'error']**
 theme|String|'primary'|Theme of the toast you prefer<br> **['primary', 'outline', 'bubble']**
 onComplete|Function|null|Trigger when toast is completed
+closeOnSwipe|Boolean|true|Closes the toast when the user swipes it
 
 
 ### Methods

--- a/src/js/show.js
+++ b/src/js/show.js
@@ -46,6 +46,8 @@ const parseOptions = function (options) {
 	// check if the toast needs to be fitted in the screen (no margin gap between screen)
 	options.fitToScreen = options.fitToScreen || null;
 
+	// check if closes the toast when the user swipes it
+	options.closeOnSwipe = typeof options.closeOnSwipe !== 'undefined' ? options.closeOnSwipe : true;
 
 	/* transform options */
 
@@ -126,49 +128,51 @@ const createToast = function (html, options) {
 		toast.innerHTML = html;
 	}
 
-	// Bind hammer
-	let hammerHandler = new Hammer(toast, {prevent_default: false});
-	hammerHandler.on('pan', function (e) {
-		let deltaX = e.deltaX;
-		let activationDistance = 80;
+	if (options.closeOnSwipe) {
+		// Bind hammer
+		let hammerHandler = new Hammer(toast, {prevent_default: false});
+		hammerHandler.on('pan', function (e) {
+			let deltaX = e.deltaX;
+			let activationDistance = 80;
 
-		// Change toast state
-		if (!toast.classList.contains('panning')) {
-			toast.classList.add('panning');
-		}
+			// Change toast state
+			if (!toast.classList.contains('panning')) {
+				toast.classList.add('panning');
+			}
 
-		let opacityPercent = 1 - Math.abs(deltaX / activationDistance);
-		if (opacityPercent < 0)
-			opacityPercent = 0;
+			let opacityPercent = 1 - Math.abs(deltaX / activationDistance);
+			if (opacityPercent < 0)
+				opacityPercent = 0;
 
-		animations.animatePanning(toast, deltaX, opacityPercent)
+			animations.animatePanning(toast, deltaX, opacityPercent)
 
-	});
+		});
 
-	hammerHandler.on('panend', function (e) {
-		let deltaX = e.deltaX;
-		let activationDistance = 80;
+		hammerHandler.on('panend', function (e) {
+			let deltaX = e.deltaX;
+			let activationDistance = 80;
 
-		// If toast dragged past activation point
-		if (Math.abs(deltaX) > activationDistance) {
+			// If toast dragged past activation point
+			if (Math.abs(deltaX) > activationDistance) {
 
-			animations.animatePanEnd(toast, function () {
-				if (typeof(options.onComplete) === "function") {
-					options.onComplete();
-				}
+				animations.animatePanEnd(toast, function () {
+					if (typeof(options.onComplete) === "function") {
+						options.onComplete();
+					}
 
-				if (toast.parentNode) {
-					_instance.remove(toast);
-				}
-			})
+					if (toast.parentNode) {
+						_instance.remove(toast);
+					}
+				})
 
-		} else {
-			toast.classList.remove('panning');
-			// Put toast back into original position
-			animations.animateReset(toast)
+			} else {
+				toast.classList.remove('panning');
+				// Put toast back into original position
+				animations.animateReset(toast)
 
-		}
-	});
+			}
+		});
+	}
 
 	// create and append actions
 	if (Array.isArray(options.action)) {


### PR DESCRIPTION
Hi.
My use case for feature: in some cases I show a toast with a toast with some info which my users need to select and copy. With the default behavior, when the user tries to select the text the toast is closed.
Default for the option is true to keep backward compatibility.