### PR TITLE
fix readme typo toastObject

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ onClick|Function(e,toastObject) |`null`|  onClick Function of action
     action : {
         text : 'Cancel',
         onClick : (e, toastObject) => {
-            toast.goAway(0);
+            toastObject.goAway(0);
         }
     },
 
@@ -152,7 +152,7 @@ onClick|Function(e,toastObject) |`null`|  onClick Function of action
         {
             text : 'Cancel',
             onClick : (e, toastObject) => {
-                toast.goAway(0);
+                toastObject.goAway(0);
             }
         },
         {


### PR DESCRIPTION
Hello!

It seems to me that `toast` variable is undefined there, instead it should be `toastObject`.

Thank you for great project! :+1: