### PR TITLE
Updated typings with class declaration and default export

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -144,12 +144,12 @@ interface Toasted {
    * @param message
    * @param options
    */
-  register (name: string, message: string, options?: ToastOptions): any
+  register (name: string, message: string, options?: ToastOptions): void
 
   /**
    * Clear all toasts
    */
-  clear (): any
+  clear (): boolean
 }
 
 declare class ToastedPlugin {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,5 +1,5 @@
-import './vue'
 import { Vue, VueConstructor } from 'vue/types/vue'
+import { PluginFunction } from "vue"
 
 interface ToastObject {
   // html element of the toast
@@ -43,7 +43,7 @@ interface ToastAction {
    * @param {ToastObject} toastObject
    * @returns {any}
    */
-  onClick?: (e, toastObject: ToastObject) => any
+  onClick?: (e: any, toastObject: ToastObject) => any
 }
 
 interface ToastOptions {
@@ -144,12 +144,16 @@ interface Toasted {
    * @param message
    * @param options
    */
-  register (name: string, message: string, options?: ToastOptions)
+  register (name: string, message: string, options?: ToastOptions): any
 
   /**
    * Clear all toasts
    */
-  clear ()
+  clear (): any
+}
+
+declare class ToastedPlugin {
+  static install: PluginFunction<never>
 }
 
 declare module 'vue/types/vue' {
@@ -161,3 +165,5 @@ declare module 'vue/types/vue' {
     $toasted: Toasted
   }
 }
+
+export default ToastedPlugin


### PR DESCRIPTION
I found that I needed the following additional declaration and export to be able to use Typescript with this plugin as per the code samples.