### PR TITLE
package.json: change typings to types

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "url": "https://github.com/shakee93/vue-toasted.git"
   },
   "main": "./dist/vue-toasted.min.js",
-  "typings": "./types/index.d.ts",
+  "types": "./types/index.d.ts",
   "scripts": {
     "dev": "cross-env NODE_ENV=development webpack-dev-server --open --hot",
     "build": "cross-env NODE_ENV=production webpack --config ./build/webpack.release.js --progress --hide-modules",


### PR DESCRIPTION
According to new TypeScript Publishing rules this field should be called `types` instead

TS Publishing Docs: https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html

Highly recommend to merge this request ASAP with that one https://github.com/shakee93/vue-toasted/pull/82

Thanks :heart: 