### PR TITLE
Updated css to account for all fontawesome classes

### DIFF
--- a/src/sass/toast.scss
+++ b/src/sass/toast.scss
@@ -78,7 +78,7 @@
     justify-content: space-between;
     box-sizing: inherit;
 
-    .material-icons, .fa, .mdi {
+    .material-icons, .fa, .fas, .far, .fab, .mdi {
       margin-right: .5rem;
       margin-left: -.4rem;
 


### PR DESCRIPTION
Fontawesome uses three classes, .fa, .fas, .far and .fab this was only account for .fa 

Before you wouldn't get styling on things like this: https://fontawesome.com/icons/bookmark?style=regular

But with this change you can.