### PR TITLE
Added `global` to the type defs for predefined toasts

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -150,6 +150,8 @@ interface Toasted {
    * Clear all toasts
    */
   clear (): boolean
+  
+  global: any
 }
 
 declare class ToastedPlugin {


### PR DESCRIPTION
This allows to use the `global` member of `this.$toasted` in typescript for registered toasts