### PR TITLE
Add ARIA attribute to improve accessibility

### DIFF
--- a/src/js/show.js
+++ b/src/js/show.js
@@ -199,6 +199,7 @@ const createIcon = (options, toast) => {
 	if (options.icon) {
 
 		let iel = document.createElement('i');
+		iel.setAttribute('aria-hidden', 'true');
 
 		switch (options.iconPack) {
 			case 'fontawesome' :

--- a/src/js/show.js
+++ b/src/js/show.js
@@ -435,16 +435,7 @@ export default function (instance, message, options) {
 	_instance = instance;
 
 	options = parseOptions(options);
-	let container = document.getElementById(_instance.id);
-
-	// Create toast container if it does not exist
-	if (container === null) {
-		// create notification container
-		container = document.createElement('div');
-		container.id = _instance.id;
-
-		document.body.appendChild(container);
-	}
+	const container = _instance.container;
 
 	options.containerClass.unshift('toasted-container');
 

--- a/src/js/toast.js
+++ b/src/js/toast.js
@@ -49,6 +49,16 @@ export const Toasted = function (_options) {
 	this.toasts = [];
 
 	/**
+	 * Element of the Toast Container
+	 */
+	this.container = null;
+
+	/**
+	 * Initiate toast container
+	 */
+	initiateToastContainer(this);
+
+	/**
 	 * Initiate custom toasts
 	 */
 	initiateCustomToasts(this);
@@ -245,6 +255,18 @@ export const initiateCustomToasts = function (instance) {
 		});
 
 	}
+};
+
+const initiateToastContainer = function (instance) {
+	// create notification container
+	const container = document.createElement('div');
+	container.id = instance.id;
+	container.setAttribute('role', 'status');
+	container.setAttribute('aria-live', 'polite');
+	container.setAttribute('aria-atomic', 'false');
+
+	document.body.appendChild(container);
+	instance.container = container;
 };
 
 const register = function (instance, name, callback, options) {


### PR DESCRIPTION
Fixes #102 

This is basic implementation of accessible toasts. I've tested on the Safari with VoiceOver.

To use `aria-live="polite"`, this PR changes behavior of the container element of toasts to be inserted into the body immediately, rather than while calling `$toasted.show()`.