### PR TITLE
Use vue-toasted with typescript

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -46,7 +46,7 @@ interface ToastAction {
   onClick?: (e: any, toastObject: ToastObject) => any
 }
 
-interface ToastOptions {
+export interface ToastOptions {
   /**
    * Position of the toast container (default: 'top-right')
    */
@@ -155,7 +155,7 @@ interface Toasted {
 }
 
 declare class ToastedPlugin {
-  static install: PluginFunction<never>
+  static install: PluginFunction<ToastOptions>
 }
 
 declare module 'vue/types/vue' {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -46,7 +46,7 @@ interface ToastAction {
   onClick?: (e: any, toastObject: ToastObject) => any
 }
 
-export interface ToastOptions {
+interface ToastOptions {
   /**
    * Position of the toast container (default: 'top-right')
    */


### PR DESCRIPTION
Hi, in order to make vue-toasted work as a Vue Plugin with Typescript I had to change the signature of the PluginFunction from never to ToastOptions, otherwise I would not be able to pass options at plugin registration time.

There's probably some other modifications needed, I'll update this PR if I find them.