### PR TITLE
add "export" to all interfaces and types

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,7 +1,7 @@
 import { Vue, VueConstructor } from 'vue/types/vue'
 import { PluginFunction } from "vue"
 
-interface ToastObject {
+export interface ToastObject {
   // html element of the toast
   el: HTMLElement,
   // change text or html of the toast
@@ -10,12 +10,12 @@ interface ToastObject {
   goAway: (delay?: number) => any
 }
 
-type ToastPosition = 'top-right' | 'top-center' | 'top-left' | 'bottom-right' | 'bottom-center' | 'bottom-left'
-type ToastType = 'success' | 'info' | 'error' | 'default'
-type ToastTheme = 'primary' | 'outline' | 'bubble'
-type ToastIconPack = 'material' | 'fontawesome' | 'custom-class' | 'callback'
+export type ToastPosition = 'top-right' | 'top-center' | 'top-left' | 'bottom-right' | 'bottom-center' | 'bottom-left'
+export type ToastType = 'success' | 'info' | 'error' | 'default'
+export type ToastTheme = 'primary' | 'outline' | 'bubble'
+export type ToastIconPack = 'material' | 'fontawesome' | 'custom-class' | 'callback'
 
-interface ToastAction {
+export interface ToastAction {
   /**
    * name of action
    */
@@ -46,7 +46,7 @@ interface ToastAction {
   onClick?: (e: any, toastObject: ToastObject) => any
 }
 
-interface ToastOptions {
+export interface ToastOptions {
   /**
    * Position of the toast container (default: 'top-right')
    */
@@ -105,7 +105,7 @@ interface ToastOptions {
   iconPack?: ToastIconPack|string
 }
 
-interface Toasted {
+export interface Toasted {
   /**
    * Show a toast with success style
    *
@@ -155,7 +155,7 @@ interface Toasted {
 }
 
 declare class ToastedPlugin {
-  static install: PluginFunction<never>
+  static install: PluginFunction<ToastOptions>
 }
 
 declare module 'vue/types/vue' {


### PR DESCRIPTION
Hello,
I have add `export` to all interfaces and types for enable to use that in https://github.com/nuxt-community/modules/tree/master/packages/toast
In same time i have implement the PR #116.

Thanks