### PR TITLE
simplify code contributions by fully automating thesetup with Gitpod

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,10 @@
+tasks:
+  - init: npm install
+    command: npm run dev
+ports:
+  - port: 8080
+    onOpen: open-preview
+
+vscode:
+  extensions:
+    - octref.vetur@0.23.0:TEzauMObB6f3i2JqlvrOpA==

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@
   <a href="https://vuejs.org/"><img src="https://img.shields.io/badge/vue-2.x-brightgreen.svg?style=flat-square"/></a>
   <a href="https://github.com/shakee93/vue-toasted/"><img src="http://img.badgesize.io/shakee93/vue-toasted/master/dist/vue-toasted.min.js?compression=gzip&style=flat-square"/></a>
   <a href="http://packagequality.com/#?package=vue-toasted"><img src="http://npm.packagequality.com/shield/vue-toasted.svg?style=flat-square"/></a>
+  <a href="https://gitpod.io/from-referrer/"><img src="https://img.shields.io/badge/Gitpod-Ready--to--Code-blue?logo=gitpod" alt="Gitpod Ready-to-Code">
+  </a>
  </p>
 
 ## Introduction
@@ -344,6 +346,11 @@ Please Report If You have Found any Issues.
 
 On Mobile Toasts will be on full width. according to the position the toast will either be on top or bottom.
 
+### Contribute using the one-click online setup.
+
+Contribute to Vue Toasted using a fully featured online development environment that will automatically: clone the repo, install the dependencies and start the webserver.
+
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
 
 ### Credits
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -50,7 +50,10 @@ module.exports = {
 	performance: {
 		hints: false
 	},
-	devtool: '#source-map'
+    devtool: '#source-map',
+    devServer: {
+        disableHostCheck: true
+    }
 }
 
 if (process.env.NODE_ENV === 'production') {


### PR DESCRIPTION
Hi! :slightly_smiling_face: 

This Pr simplifies code contributions by fully automating the dev setup with Gitpod(a free online VS Code like IDE) for contributing, with a single click it'll launch a workspace and automatically:

- clone the `vue-toasted` repo.
- install the dependencies.
- start the webserver.

So that anyone interested in contributing can start straight away.

You can give it a try on my fork of the repo via the following link:

https://gitpod.io/#https://github.com/nisarhassan12/vue-toasted

This is how it looks: 

![image](https://user-images.githubusercontent.com/46004116/78858181-0d23bf00-7a45-11ea-8648-49a62c287ae1.png)
