### PR TITLE
Fixes error which is manipulating the existing object.className Array resulting in wrong css properties of toast in nuxt

### DIFF
--- a/src/js/show.js
+++ b/src/js/show.js
@@ -78,7 +78,9 @@ const parseOptions = function (options) {
 	// toast class
 	if (options.className && typeof(options.className) === "string") {
 		options.className = options.className.split(' ');
-	}
+	} else if (options.className && Array.isArray(options.className) {
+	        options.className = JSON.parse(JSON.stringify(options.className));
+        }
 
 	if (!options.className) {
 		options.className = [];


### PR DESCRIPTION
version "@nuxtjs/toast": "^3.3.1",

cannot tell whether the problem exists in plain vue.js, too, but in nuxt the error can be reproduced by:

- setup toasts in config and set className attribute to an Array

``` javascript
  toast: {
    position: 'top-center',
    className: ['my-custom-toast'],
    action: {
      text: 'X',
      onClick: (e, toastObject) => {
        toastObject.goAway(0)
      },
    },
  },
```

- fire a `toast.success("test", { duration: 3000 })`
- fire a `toast.error("error test", { duration: 3000 })`
- fire a `toast.success("test", { duration: 3000 })` __it will appear as an error toast__ 🟥 

Looking at the source code, I assume it happened because of an array shallow copy bug.

https://github.com/shakee93/vue-toasted/blob/db5ccc47b9b7b27f097dde0943d67f4269c6be0d/src/js/show.js#L79

When String was used, `options.className` was reassigned to a new Array, but underlying options.className had items pushed to it, modifying in place.