### PR TITLE
Add object config support to iconPack option

### DIFF
--- a/src/js/show.js
+++ b/src/js/show.js
@@ -343,50 +343,62 @@ const createAction = (action, toastObject) => {
 
 		// create icon element
 		let iel = document.createElement('i');
+		
+		if(typeof _options.iconPack === 'string') {
+			switch (_options.iconPack) {
+				case 'fontawesome' :
+					iel.classList.add('fa');
 
+					if(action.icon.includes('fa-')) {
+						iel.classList.add(action.icon.trim());
+					}
+					else {
+						iel.classList.add('fa-' + action.icon.trim());
+					}
 
-		switch (_options.iconPack) {
-			case 'fontawesome' :
-				iel.classList.add('fa');
+					break;
+				case 'mdi':
+					iel.classList.add('mdi');
 
-				if(action.icon.includes('fa-')) {
-					iel.classList.add(action.icon.trim());
-				}
-				else {
-					iel.classList.add('fa-' + action.icon.trim());
-				}
+					if (action.icon.includes('mdi-')) {
+						iel.classList.add(action.icon.trim());
+					}
+					else {
+						iel.classList.add('mdi-' + action.icon.trim());
+					}
 
-				break;
-			case 'mdi':
-				iel.classList.add('mdi');
+					break;
+				case 'custom-class':
 
-				if (action.icon.includes('mdi-')) {
-					iel.classList.add(action.icon.trim());
-				}
-				else {
-					iel.classList.add('mdi-' + action.icon.trim());
-				}
+					if (typeof action.icon === 'string') {
+						action.icon.split(' ').forEach((className) => {
+							el.classList.add(className)
+						})
+					}
+					else if (Array.isArray(action.icon)) {
+						action.icon.forEach((className) => {
+							el.classList.add(className.trim())
+						})
+					}
 
-				break;
-			case 'custom-class':
-
-				if (typeof action.icon === 'string') {
-					action.icon.split(' ').forEach((className) => {
-						el.classList.add(className)
-					})
-				}
-				else if (Array.isArray(action.icon)) {
-					action.icon.forEach((className) => {
-						el.classList.add(className.trim())
-					})
-				}
-
-				break;
-			default:
-				iel.classList.add('material-icons');
-				iel.textContent = action.icon;
+					break;
+				default:
+					iel.classList.add('material-icons');
+					iel.textContent = action.icon;
+			}
 		}
 
+		if (typeof _options.iconPack === 'object') {
+			const iconClasses = _options.iconPack.classes ? _options.iconPack.classes : ['material-icons'];
+
+			iconClasses.forEach(iconClass => {
+				iel.classList.add(iconClass);
+			})
+
+			if (options.iconPack.textContent) {
+				iel.textContent = action.icon;
+			}
+		}
 
 		// append it to the button
 		el.appendChild(iel);

--- a/src/js/show.js
+++ b/src/js/show.js
@@ -395,7 +395,7 @@ const createAction = (action, toastObject) => {
 				iel.classList.add(iconClass);
 			})
 
-			if (options.iconPack.textContent) {
+			if (_options.iconPack.textContent) {
 				iel.textContent = action.icon;
 			}
 		}

--- a/src/js/show.js
+++ b/src/js/show.js
@@ -263,6 +263,18 @@ const createIcon = (options, toast) => {
 		}
 	}
 
+	if (typeof options.iconPack === 'object') {
+		const iconClasses = options.iconPack.classes ? options.iconPack.classes : ['material-icons'];
+
+		iconClasses.forEach(iconClass => {
+			iel.classList.add(iconClass);
+		})
+
+		if (options.iconPack.textContent) {
+			iel.textContent = (options.icon.name) ? options.icon.name : options.icon;
+		}
+	}
+
 	if (options.icon.after) {
 		iel.classList.add('after');
 	}

--- a/src/js/show.js
+++ b/src/js/show.js
@@ -197,13 +197,13 @@ const createToast = function (html, options) {
 };
 
 const createIcon = (options, toast) => {
-
 	// add material icon if available
-	if (options.icon) {
-
-		let iel = document.createElement('i');
-		iel.setAttribute('aria-hidden', 'true');
-
+	if (!options.icon) return
+	
+	let iel = document.createElement('i');
+	iel.setAttribute('aria-hidden', 'true');
+	
+	if(typeof options.iconPack === 'string') {
 		switch (options.iconPack) {
 			case 'fontawesome' :
 
@@ -261,14 +261,13 @@ const createIcon = (options, toast) => {
 				iel.classList.add('material-icons');
 				iel.textContent = (options.icon.name) ? options.icon.name : options.icon;
 		}
-
-		if (options.icon.after) {
-			iel.classList.add('after');
-		}
-
-		appendIcon(options, iel, toast);
 	}
 
+	if (options.icon.after) {
+		iel.classList.add('after');
+	}
+
+	appendIcon(options, iel, toast);
 }
 
 const appendIcon = (options, el, toast) => {


### PR DESCRIPTION
Sorry for the duplicate PR, will remove the original one as it was based on a master branch.

This PR allows us to set iconPack to an object like so:

```
iconPack: {
    classes: ['material-icons-round'],
    textContent: true,
}
```

In this example config this sets the icon element classes to `material-icons-round` and uses the icon or icon name as the textContent `{ icon: 'info' }` or `{ icon: { name: 'info' } }` would both set the icon textContent to `info`. 

This change makes it possible to use material icon variations but should also be useful for other iconPack implementation.