### PR TITLE
Stops toasts stretching inside container if msg length vary

### DIFF
--- a/src/sass/toast.scss
+++ b/src/sass/toast.scss
@@ -25,33 +25,39 @@
   &.top-right {
     top: 10%;
     right: 7%;
+    align-items: flex-end;
   }
 
   &.top-left {
     top: 10%;
     left: 7%;
+    align-items: flex-start;
   }
 
   &.top-center {
     top: 10%;
     left: 50%;
     transform: translateX(-50%);
+    align-items: center;
   }
 
   &.bottom-right {
     right: 5%;
     bottom: 7%;
+    align-items: flex-end;
   }
 
   &.bottom-left {
     left: 5%;
     bottom: 7%;
+    align-items: flex-start;
   }
 
   &.bottom-center {
     left: 50%;
     transform: translateX(-50%);
     bottom: 7%;
+    align-items: center;
   }
 
   // fix positioning floating


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/42934159/133925954-bc4c3e60-44fb-41a8-9177-e4dcc6acba27.png)
After:
![image](https://user-images.githubusercontent.com/42934159/133925940-70b1408f-d368-4fcc-8b02-3d8864d5cc41.png)
